### PR TITLE
[ui] introduce navbar

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="An interactive playground for Playwright with various examples."/>
-    <title>Playwright Playground</title>
+    <title>Try Playwright</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { Examples, Example } from './constants'
 import { getDropdownTitle, decodeCode, runCode } from './utils'
 import ResponseFile from './components/ResponseFile'
 import ShareButton from './components/ShareButton'
+import Header from './components/Header'
 
 const App = () => {
   const [code, setCode] = useState<string>("")
@@ -53,11 +54,10 @@ const App = () => {
   }
 
   return (
+    <>
+    <Header />
     <Grid>
       <Row>
-        <Col xs={24}>
-          <h1>Playwright Playground</h1>
-        </Col>
         <Col xs={24} md={12}>
           {loading && <Loader center content="loading" backdrop style={{ zIndex: 10 }} />}
           <Panel header={<>
@@ -100,16 +100,9 @@ const App = () => {
             </>}
           </Panel>
         </Col>
-        <Col sm={24}>
-          <Footer style={{ textAlign: "center", marginTop: 4 }}>
-            Open Source on {' '}
-            <a href="https://github.com/mxschmitt/try-playwright" target="_blank" rel="noopener noreferrer">
-              GitHub
-            </a>.
-          </Footer>
-        </Col>
       </Row>
     </Grid >
+    </>
   );
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Row, Col, Grid, IconButton, Icon, Loader, Panel, Dropdown, Footer, Notification } from 'rsuite'
+import { Row, Col, Grid, IconButton, Icon, Loader, Panel, Dropdown, Notification } from 'rsuite'
 import MonacoEditor from 'react-monaco-editor';
 import monacoEditor from 'monaco-editor'
 

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Nav, Icon, Loader, Panel, Dropdown, Footer, Notification, Navbar } from 'rsuite'
+import { Nav, Icon, Navbar } from 'rsuite'
 
 const Header = () => {
   return (

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Nav, Icon, Loader, Panel, Dropdown, Footer, Notification, Navbar } from 'rsuite'
+
+const Header = () => {
+  return (
+    <Navbar appearance="inverse">
+      <Navbar.Header>
+        <Nav>
+          <Nav.Item><strong>Try Playwright</strong></Nav.Item>
+        </Nav>
+      </Navbar.Header>
+      <Navbar.Body>
+        <Nav pullRight>
+          <Nav.Item href="https://github.com/mxschmitt/try-playwright" icon={<Icon icon="github" />}>
+            View Source
+          </Nav.Item>
+        </Nav>
+      </Navbar.Body>
+    </Navbar>
+    )
+  }
+  
+  export default Header;


### PR DESCRIPTION
Wanted to kick start some UI polish. This PR replaces the existing h1 with a fluid navbar, and updates the page title to be "Try Playwright". If this direction makes sense, I'll follow with a PR to use a fluid layout for the grid.

UI after this change:

![Screen Shot 2020-03-02 at 12 02 06 PM](https://user-images.githubusercontent.com/284612/75712925-a957ea80-5c7d-11ea-959f-6e91c3277986.png)
