### PR TITLE
fix: remove firefox from examples to gain speed improvements

### DIFF
--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -44,7 +44,7 @@ export const Examples: Example[] = [
 })();`
   }, {
     title: "Generate a PDF",
-    description:"This example will search for 'Google' on Google and stores the rendered site as a PDF.",
+    description: "This example will search for 'Google' on Google and stores the rendered site as a PDF.",
     code: `const playwright = require("playwright");
 
 (async () => {

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -7,11 +7,11 @@ export interface Example {
 export const Examples: Example[] = [
   {
     title: "Page screenshot",
-    description: "This code snippet navigates to whatsmyuseragent.org in Chromium, Firefox and WebKit, and saves 3 screenshots.",
+    description: "This code snippet navigates to whatsmyuseragent.org in Chromium and WebKit, and saves 3 screenshots.",
     code: `const playwright = require("playwright");
 
 (async () => {
-  for (const browserType of ['chromium', 'firefox', 'webkit']) {
+  for (const browserType of ['chromium', 'webkit']) {
     const browser = await playwright[browserType].launch();
     const context = await browser.newContext();
     const page = await context.newPage();
@@ -83,11 +83,11 @@ const { saveVideo } = require('playwright-video');
 })();`
   }, {
     title: "Evaluate in browser context",
-    description: "This code snippet navigates to example.com in Firefox, and executes a script in the page context.",
+    description: "This code snippet navigates to example.com in WebKit, and executes a script in the page context.",
     code: `const playwright = require("playwright");
 
 (async () => {
-  const browser = await playwright.firefox.launch();
+  const browser = await playwright.webkit.launch();
   const context = await browser.newContext();
   const page = await context.newPage();
   await page.goto('https://www.example.com/');

--- a/tests/.qawolf/tests/try-playwright.test.js
+++ b/tests/.qawolf/tests/try-playwright.test.js
@@ -38,9 +38,9 @@ describe('Examples', () => {
   it("1: should be able to make screenshots in all browsers", async () => {
     await executeExample(1)
     const imageCount = await getImageCount()
-    expect(imageCount).toBe(3)
+    expect(imageCount).toBe(2)
     const imageNames = await getFileNames()
-    expect(imageNames).toEqual(["example-chromium.png", "example-firefox.png", "example-webkit.png"])
+    expect(imageNames).toEqual(["example-chromium.png", "example-webkit.png"])
   })
   it("2: should be able to set the geolocation", async () => {
     await executeExample(2)


### PR DESCRIPTION
Firefox is significant slower. So we simply remove it to get better experience on the platform.