### PR TITLE
fix: stop control service if amqp disconnects

### DIFF
--- a/file-service/main.go
+++ b/file-service/main.go
@@ -163,7 +163,10 @@ func main() {
 			log.Fatalf("could not listen: %v", err)
 		}
 	}()
-	<-stop
+	signal := <-stop
+	log.Printf("received stop signal: %s", signal)
+	log.Println("shutting down server gracefully")
+
 	if err := s.Stop(); err != nil {
 		log.Fatalf("could not stop: %v", err)
 	}


### PR DESCRIPTION
Yesterday we had a major outage on Try Playwright for 9 hours which was caused by a new manual deployment which updated RabbitMQ and I was too confident that it will work without checking it by hand. I received a monitoring alert immediately but thought its a false positive. By that RabbitMQ restarted but the control microservice didn't reconnect and kept a closed connection state inside. So all incoming requests lead to an error.

In this Pull Request we implemented a change which shuts down the microservice immediately if the amqp connection gets closed or errors and let Docker/K8 decide to restart and schedule a restart.

Action items:

- Implemented exit on amqp error (this PR)
- Added SMS notification for monitoring alerts on Checkly
- Checking now each deployment manually, not only locally

Notification history (Europe/Berlin time):

- failure alert - 9:27 pm - with email
- restarted the control microservice by hand - 06:00am
- recover alert - 6:06 am - with email

