### PR TITLE
fix: uncaughtException handling in Node.js 15

### DIFF
--- a/control-service/main.go
+++ b/control-service/main.go
@@ -152,6 +152,7 @@ type runPayload struct {
 
 type workerResponsePayload struct {
 	Success  bool   `json:"success"`
+	Error    string `json:"error"`
 	Version  string `json:"version"`
 	Duration int64  `json:"duration"`
 	Files    []struct {

--- a/e2e/try-playwright.spec.ts
+++ b/e2e/try-playwright.spec.ts
@@ -151,4 +151,28 @@ describe("should handle platform core related features", test => {
       timeout: 40 * 1000
     })
   })
+  it("should handle uncaughtException correctly", async ({ page }) => {
+    await page.goto(ROOT_URL, { waitUntil: "networkidle" });
+    await page.click(".monaco-editor")
+    await page.keyboard.press("Meta+KeyA")
+    await page.keyboard.type(`// @ts-check
+const playwright = require("playwright");
+
+(async () => {
+  const browser = await playwright.chromium.launch();
+  const page = await browser.newPage();
+  page.route("**/*", () => {
+    throw new Error("foobar!")`)
+    await page.keyboard.press("ArrowDown")
+    await page.keyboard.type(`
+     await page.goto("https://example.com")
+  await browser.close();`)
+    await page.keyboard.press("ArrowDown")
+    await page.keyboard.press("ArrowDown")
+    await page.keyboard.type("();")
+    await page.click("text='Run'")
+    await page.waitForSelector("text='Error: foobar!'", {
+      timeout: 5 * 1000
+    })
+  })
 })

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -30,8 +30,8 @@ const QUEUE_NAME = 'rpc_queue';
     try {
       response = await runUntrustedCode(payload?.code)
     } catch (error) {
-      response = { success: false, error: error.toString() }
-      console.log("Errored request", error)
+      response = { success: false, error: String(error) }
+      console.log(`Errored request: ${error}`)
       Sentry.captureException(error)
     }
     channel.sendToQueue(msg.properties.replyTo,


### PR DESCRIPTION
This payload caused an infinity retry exit loop:

```js
// @ts-check
const playwright = require("playwright");

(async () => {
  const browser = await playwright.chromium.launch();
  const page = await browser.newPage();
  page.route("**/*", () => {
    throw new Error("foobar")
  })
  await page.goto("https://example.com")
  await browser.close();
})();
```