### PR TITLE
fix: firefox failed https requests due proxy misconfiguration

### DIFF
--- a/e2e/tests/visual.spec.ts
+++ b/e2e/tests/visual.spec.ts
@@ -116,7 +116,7 @@ describe("Share functionality", () => {
     await page.goto(ROOT_URL, { waitUntil: "networkidle" });
     await page.click("text='Share'")
     await page.waitForTimeout(500)
-    expect(page.url()).toBe(`${ROOT_URL}/?e=page-screenshot`)
+    expect(page.url()).toBe(`${ROOT_URL}/?l=javascript&e=page-screenshot`)
   })
   it("should generate share URL", async ({ page }) => {
     await page.goto(ROOT_URL, { waitUntil: "networkidle" });
@@ -127,7 +127,7 @@ describe("Share functionality", () => {
 
     await page.click("text='Share'")
     await page.waitForTimeout(500)
-    expect(page.url().startsWith(`${ROOT_URL}/?s=`)).toBeTruthy()
+    expect(page.url().startsWith(`${ROOT_URL}/?l=javascript&s=`)).toBeTruthy()
 
     await page.reload()
     await page.click("text='Run'")

--- a/frontend/src/components/ShareButton/index.tsx
+++ b/frontend/src/components/ShareButton/index.tsx
@@ -6,11 +6,12 @@ import styles from './index.module.css'
 import { pushNewURL } from '../../utils'
 
 const ShareButton: React.FunctionComponent = () => {
-    const { code, examples } = useContext(CodeContext)
+    const { code, codeLanguage, examples } = useContext(CodeContext)
     const handleOnClick = async (): Promise<void> => {
         const urlParams = new URLSearchParams(window.location.search);
         urlParams.delete("e")
         urlParams.delete("s")
+        urlParams.set("l", codeLanguage)
         // if there is a example existing with the same code, then use this
         const example = examples.find(example => example.code === code)
         if (!example) {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -87,7 +87,7 @@ func (w *Worker) ExecCommand(name string, args ...string) error {
 		Env: append(
 			os.Environ(),
 			fmt.Sprintf("http_proxy=%s", workerProxy),
-			fmt.Sprintf("HTTPS_PROXY=%s", workerProxy),
+			fmt.Sprintf("https_proxy=%s", workerProxy),
 		),
 	}
 	if err := c.Run(); err != nil {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -88,6 +88,8 @@ func (w *Worker) ExecCommand(name string, args ...string) error {
 			os.Environ(),
 			fmt.Sprintf("http_proxy=%s", workerProxy),
 			fmt.Sprintf("HTTPS_PROXY=%s", workerProxy),
+			// Firefox needs it currently in lower-case. See
+			// https://github.com/microsoft/playwright/issues/6094
 			fmt.Sprintf("https_proxy=%s", workerProxy),
 		),
 	}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -87,6 +87,7 @@ func (w *Worker) ExecCommand(name string, args ...string) error {
 		Env: append(
 			os.Environ(),
 			fmt.Sprintf("http_proxy=%s", workerProxy),
+			fmt.Sprintf("HTTPS_PROXY=%s", workerProxy),
 			fmt.Sprintf("https_proxy=%s", workerProxy),
 		),
 	}


### PR DESCRIPTION
See here for more details: https://github.com/microsoft/playwright/issues/6094

Seems to be the last blocker for the go live.